### PR TITLE
fix: Consume `self` in Responder

### DIFF
--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -160,8 +160,7 @@ impl<Res> Responder<Res> {
         self.response_sender.send(response).map_err(RespondError)
     }
 
-    /// Checks if a response has already been sent, or the associated receiver
-    /// handle for the response listener has been dropped.
+    /// Checks if the associated receiver handle for the response listener has been dropped.
     pub fn is_closed(&self) -> bool {
         self.response_sender.is_closed()
     }
@@ -243,7 +242,7 @@ pub fn channel_with_timeout<Req, Res>(
     (request_sender, request_receiver)
 }
 
-/// A wrapper around [`bmrng::RequestReceiver`] that implements [`Stream`].
+/// A wrapper around [`RequestReceiver`] that implements [`Stream`].
 #[derive(Debug)]
 pub struct RequestReceiverStream<Req, Res> {
     inner: RequestReceiver<Req, Res>,

--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -30,7 +30,7 @@ pub struct RequestReceiver<Req, Res> {
 /// Instances are created by calling [`RequestSender::send_receive()`] or [`RequestSender::send()`]
 #[derive(Debug)]
 pub struct Responder<Res> {
-    response_sender: Option<oneshot::Sender<Res>>,
+    response_sender: oneshot::Sender<Res>,
 }
 
 /// Receive responses from a [`Responder`]
@@ -152,28 +152,18 @@ impl<Res> ResponseReceiver<Res> {
 
 impl<Res> Responder<Res> {
     pub(crate) fn new(response_sender: oneshot::Sender<Res>) -> Self {
-        Self {
-            response_sender: Some(response_sender),
-        }
+        Self { response_sender }
     }
 
     /// Responds a request from the [`RequestSender`] which finishes the request
-    pub fn respond(&mut self, response: Res) -> Result<(), RespondError<Res>> {
-        match self.response_sender.take() {
-            Some(response_sender) => response_sender
-                .send(response)
-                .map_err(RespondError::ChannelClosed),
-            None => Err(RespondError::AlreadyReplied(response)),
-        }
+    pub fn respond(self, response: Res) -> Result<(), RespondError<Res>> {
+        self.response_sender.send(response).map_err(RespondError)
     }
 
     /// Checks if a response has already been sent, or the associated receiver
     /// handle for the response listener has been dropped.
     pub fn is_closed(&self) -> bool {
-        match &self.response_sender {
-            Some(sender) => sender.is_closed(),
-            None => true,
-        }
+        self.response_sender.is_closed()
     }
 }
 

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -120,8 +120,7 @@ impl<Res> UnboundedResponder<Res> {
         self.response_sender.send(response).map_err(RespondError)
     }
 
-    /// Checks if a response has already been sent, or the associated receiver
-    /// handle for the response listener has been dropped.
+    /// Checks if the associated receiver handle for the response listener has been dropped.
     pub fn is_closed(&self) -> bool {
         self.response_sender.is_closed()
     }
@@ -157,7 +156,7 @@ pub fn channel_with_timeout<Req, Res>(
     (request_sender, request_receiver)
 }
 
-/// A wrapper around [`bmrng::unbounded::UnboundedRequestReceiver`] that implements [`Stream`].
+/// A wrapper around [`UnboundedRequestReceiver`] that implements [`Stream`].
 #[derive(Debug)]
 pub struct UnboundedRequestReceiverStream<Req, Res> {
     inner: UnboundedRequestReceiver<Req, Res>,

--- a/tests/loom_bounded.rs
+++ b/tests/loom_bounded.rs
@@ -38,7 +38,7 @@ fn closing_tx_res() {
         });
 
         let v = block_on(rx.recv());
-        let (req, mut responder) = v.unwrap();
+        let (req, responder) = v.unwrap();
         let v = responder.respond(req * 2);
         assert_ok!(v);
 


### PR DESCRIPTION
Issue:  #1

Consume `self` in `Responder`, make it impossible to attempt to send a response more than once. Remove the `AlreadyReplied` error variant, convert `RespondError` into a struct.

BREAKING CHANGE: This changes the `Responder` and `RespondError` interfaces. This change will be released in version `0.5.0`