### PR TITLE
Using a `Request` trait with a type alias `Response` instead of two generic types

### DIFF
--- a/benches/bench_channel_async.rs
+++ b/benches/bench_channel_async.rs
@@ -1,6 +1,12 @@
-use bmrng::channel;
+use bmrng::{channel, Request};
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use tokio::sync::mpsc;
+
+struct Req;
+
+impl Request for Req {
+    type Response = ();
+}
 
 fn rt() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()
@@ -16,15 +22,15 @@ fn benchmark_async(c: &mut Criterion) {
 
     group.bench_function("bmrng async, bounded, capacity = 1", move |b| {
         b.to_async(rt()).iter(|| async {
-            let (tx, rx) = channel::<(), ()>(1);
+            let (tx, rx) = channel::<Req>(1);
             tokio::spawn(async move {
                 let mut rx = rx;
                 let req = rx.recv().await;
                 if let Ok(req) = req {
-                    let _ = req.1.respond(());
+                    let _ = req.responder.respond(());
                 }
             });
-            let _ = tx.send_receive(()).await;
+            let _ = tx.send_receive(Req).await;
         })
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,12 @@
 //! See [`bmrng::channel()`](crate::channel()) for a channel with backpressure and
 //! [`bmrng::unbounded::channel()`](crate::unbounded::channel()) for a channel without backpressure.
 
+/// request
+pub trait Request {
+    /// response
+    type Response;
+}
+
 mod bounded;
 pub use self::bounded::{
     channel, channel_with_timeout, Payload, RequestReceiver, RequestReceiverStream, RequestSender,

--- a/tests/loom_bounded.rs
+++ b/tests/loom_bounded.rs
@@ -1,14 +1,22 @@
+use bmrng::{channel, Request, Payload};
 use loom::future::block_on;
 use loom::thread;
+
+#[derive(Debug)]
+struct Req(u32);
+
+impl Request for Req {
+    type Response = u32;
+}
 
 #[test]
 #[cfg(not(tarpaulin))]
 fn closing_tx() {
     loom::model(|| {
-        let (tx, mut rx) = bmrng::channel::<u32, u32>(16);
+        let (tx, mut rx) = channel::<Req>(16);
 
         thread::spawn(move || {
-            let res = block_on(tx.send(4));
+            let res = block_on(tx.send(Req(4)));
             assert!(res.is_ok());
             drop(tx);
         });
@@ -25,18 +33,18 @@ fn closing_tx() {
 #[cfg(not(tarpaulin))]
 fn closing_tx_res() {
     loom::model(|| {
-        let (tx, mut rx) = bmrng::channel::<u32, u32>(16);
+        let (tx, mut rx) = channel::<Req>(16);
 
         thread::spawn(move || {
-            let res = block_on(tx.send(5));
+            let res = block_on(tx.send(Req(5)));
             let repl = block_on(res.unwrap().recv());
             assert_eq!(repl, Ok(10));
             drop(tx);
         });
 
         let v = block_on(rx.recv());
-        let (req, responder) = v.unwrap();
-        let v = responder.respond(req * 2);
+        let Payload { request, responder } = v.unwrap();
+        let v = responder.respond(request.0 * 2);
         assert!(v.is_ok());
 
         let v = block_on(rx.recv());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,95 +1,101 @@
-use bmrng::unbounded::UnboundedRequestReceiverStream;
-use bmrng::{error::*, RequestReceiverStream};
+use bmrng::{unbounded::UnboundedRequestReceiverStream, error::*, RequestReceiverStream, Request, Payload, unbounded::UnboundedPayload};
 use futures_util::stream::StreamExt;
 use tokio::time::{advance, pause, resume, sleep, Duration};
 
+#[derive(Debug, PartialEq)]
+struct Req(u32);
+
+impl Request for Req {
+    type Response = u32;
+}
+
 #[tokio::test]
 async fn unbounded_send_receive() {
-    let (tx, mut rx) = bmrng::unbounded_channel::<i32, i32>();
+    let (tx, mut rx) = bmrng::unbounded_channel::<Req>();
     tokio::spawn(async move {
-        let (input, responder) = rx.recv().await.expect("Unexpected err");
+        let UnboundedPayload { request, responder } = rx.recv().await.expect("Unexpected err");
         assert!(!responder.is_closed());
-        let res = responder.respond(input * input);
+        let res = responder.respond(request.0 + 4);
         assert!(res.is_ok());
     });
     assert!(!tx.is_closed());
-    let response = tx.send_receive(8).await;
+    let response = tx.send_receive(Req(8)).await;
     assert!(tx.is_closed());
-    assert_eq!(response, Ok(64));
+    assert_eq!(response, Ok(12));
 }
 
 #[tokio::test]
 async fn bounded_send_receive() {
-    let (tx, mut rx) = bmrng::channel::<i32, i32>(1);
+    let (tx, mut rx) = bmrng::channel::<Req>(1);
     tokio::spawn(async move {
-        let (input, responder) = rx.recv().await.expect("Unexpected err");
+        let Payload { request, responder } = rx.recv().await.expect("Unexpected err");
         assert!(!responder.is_closed());
-        let res = responder.respond(input * input);
+        let res = responder.respond(request.0 + 4);
         assert!(res.is_ok());
     });
     assert!(!tx.is_closed());
-    let response = tx.send_receive(8).await;
+    let response = tx.send_receive(Req(8)).await;
     assert!(tx.is_closed());
-    assert_eq!(response, Ok(64));
+    assert_eq!(response, Ok(12));
 }
 
 #[tokio::test]
 async fn unbounded_request_sender_clone() {
-    let (tx, mut rx) = bmrng::unbounded_channel::<i32, i32>();
+    let (tx, mut rx) = bmrng::unbounded_channel::<Req>();
     let tx2 = tx.clone();
     tokio::spawn(async move {
-        let response = tx2.send_receive(7).await;
+        let response = tx2.send_receive(Req(7)).await;
         assert_eq!(response, Ok(49));
     });
     tokio::spawn(async move {
-        while let Ok((input, responder)) = rx.recv().await {
+        while let Ok(UnboundedPayload { request, responder }) = rx.recv().await {
             assert!(!responder.is_closed());
-            let res = responder.respond(input * input);
+            let res = responder.respond(request.0 + 4);
             assert!(res.is_ok());
         }
     });
 
     assert!(!tx.is_closed());
-    let response = tx.send_receive(8).await;
-    assert_eq!(response, Ok(64));
+    let response = tx.send_receive(Req(8)).await;
+    assert_eq!(response, Ok(12));
 }
 
 #[tokio::test]
 async fn bounded_request_sender_clone() {
-    let (tx, mut rx) = bmrng::channel::<i32, i32>(1);
+    let (tx, mut rx) = bmrng::channel::<Req>(1);
     let tx2 = tx.clone();
     tokio::spawn(async move {
-        let response = tx2.send_receive(7).await;
-        assert_eq!(response, Ok(49));
+        let response = tx2.send_receive(Req(7)).await;
+        assert_eq!(response, Ok(11));
     });
     tokio::spawn(async move {
-        while let Ok((input, responder)) = rx.recv().await {
+        while let Ok(Payload { request, responder }) = rx.recv().await {
             assert!(!responder.is_closed());
-            let res = responder.respond(input * input);
+            let res = responder.respond(request.0 + 4);
             assert!(res.is_ok());
         }
     });
 
     assert!(!tx.is_closed());
-    let response = tx.send_receive(8).await;
-    assert_eq!(response, Ok(64));
+    let response = tx.send_receive(Req(8)).await;
+    assert_eq!(response, Ok(12));
 }
 
 #[tokio::test]
 async fn unbounded_drop_while_waiting_for_response() {
-    let (tx, mut rx) = bmrng::unbounded_channel::<i32, i32>();
+    let (tx, mut rx) = bmrng::unbounded_channel::<Req>();
     let task = tokio::spawn(async move {
-        let (_, responder) = rx.recv().await.expect("Unexpected err");
+        let UnboundedPayload { request: _, responder } = rx.recv().await.expect("Unexpected err");
         drop(responder);
     });
-    let response = tx.send_receive(8).await;
+    let response = tx.send_receive(Req(8)).await;
     assert!(tokio::join!(task).0.is_ok());
     assert_eq!(response, Err(RequestError::RecvError));
 }
 
 #[tokio::test]
 async fn unbounded_drop_while_waiting_for_request() {
-    let (tx, mut rx) = bmrng::unbounded_channel::<i32, i32>();
+    let (tx, mut rx) = bmrng::unbounded_channel::<Req>();
     let task = tokio::spawn(async move {
         if rx.recv().await.is_ok() {
             panic!("this should not be ok")
@@ -101,32 +107,32 @@ async fn unbounded_drop_while_waiting_for_request() {
 
 #[tokio::test]
 async fn unbounded_drop_sender_while_sending_response() {
-    let (tx, mut rx) = bmrng::unbounded_channel::<i32, i32>();
+    let (tx, mut rx) = bmrng::unbounded_channel::<Req>();
     let task = tokio::spawn(async move {
-        let (_, responder) = rx.recv().await.expect("Received err");
+        let UnboundedPayload { request: _, responder } = rx.recv().await.expect("Received err");
         let respond_result = responder.respond(42);
         assert_eq!(respond_result, Err(RespondError(42)));
     });
-    let response_receiver = tx.send(21);
+    let response_receiver = tx.send(Req(21));
     drop(response_receiver);
     assert!(tokio::join!(task).0.is_ok());
 }
 
 #[tokio::test]
 async fn bounded_drop_while_waiting_for_response() {
-    let (tx, mut rx) = bmrng::channel::<i32, i32>(1);
+    let (tx, mut rx) = bmrng::channel::<Req>(1);
     let task = tokio::spawn(async move {
-        let (_, responder) = rx.recv().await.expect("Unexpected err");
+        let Payload { request: _, responder } = rx.recv().await.expect("Unexpected err");
         drop(responder);
     });
-    let response = tx.send_receive(8).await;
+    let response = tx.send_receive(Req(8)).await;
     assert!(tokio::join!(task).0.is_ok());
     assert_eq!(response, Err(RequestError::RecvError));
 }
 
 #[tokio::test]
 async fn bounded_drop_while_waiting_for_request() {
-    let (tx, mut rx) = bmrng::channel::<i32, i32>(1);
+    let (tx, mut rx) = bmrng::channel::<Req>(1);
     let task = tokio::spawn(async move {
         rx.recv().await.expect_err("this should not be ok");
     });
@@ -136,55 +142,55 @@ async fn bounded_drop_while_waiting_for_request() {
 
 #[tokio::test]
 async fn bounded_drop_sender_while_sending_response() {
-    let (tx, mut rx) = bmrng::channel::<i32, i32>(1);
+    let (tx, mut rx) = bmrng::channel::<Req>(1);
     let task = tokio::spawn(async move {
-        let (_, responder) = rx.recv().await.expect("Unexpected err");
+        let Payload { request: _, responder } = rx.recv().await.expect("Unexpected err");
         let respond_result = responder.respond(42);
         assert_eq!(respond_result, Err(RespondError(42)));
     });
-    let response_receiver = tx.send(21).await;
+    let response_receiver = tx.send(Req(21)).await;
     drop(response_receiver);
     assert!(tokio::join!(task).0.is_ok());
 }
 
 #[tokio::test]
 async fn bounded_close_request_receiver() {
-    let (tx, mut rx) = bmrng::channel::<i32, i32>(4);
+    let (tx, mut rx) = bmrng::channel::<Req>(4);
     let task = tokio::spawn(async move {
         rx.close();
-        let (input, responder) = rx.recv().await.unwrap();
-        assert!(responder.respond(input * 2).is_ok());
+        let Payload { request, responder } = rx.recv().await.unwrap();
+        assert!(responder.respond(request.0 * 2).is_ok());
     });
-    let mut response_receiver = tx.send(21).await.unwrap();
+    let mut response_receiver = tx.send(Req(21)).await.unwrap();
     let response = response_receiver.recv().await;
     assert_eq!(response, Ok(42));
     drop(response_receiver);
-    assert!(tx.send(1).await.is_err());
+    assert!(tx.send(Req(1)).await.is_err());
     assert!(tokio::join!(task).0.is_ok());
 }
 
 #[tokio::test]
 async fn unbounded_close_request_receiver() {
-    let (tx, mut rx) = bmrng::unbounded_channel::<i32, i32>();
+    let (tx, mut rx) = bmrng::unbounded_channel::<Req>();
     let task = tokio::spawn(async move {
         rx.close();
-        let (input, responder) = rx.recv().await.unwrap();
-        assert!(responder.respond(input * 2).is_ok());
+        let UnboundedPayload { request, responder } = rx.recv().await.unwrap();
+        assert!(responder.respond(request.0 * 2).is_ok());
     });
-    let mut response_receiver = tx.send(21).unwrap();
+    let mut response_receiver = tx.send(Req(21)).unwrap();
     let response = response_receiver.recv().await;
     assert_eq!(response, Ok(42));
     drop(response_receiver);
-    assert!(tx.send(1).is_err());
+    assert!(tx.send(Req(1)).is_err());
     assert!(tokio::join!(task).0.is_ok());
 }
 
 #[tokio::test]
 async fn bounded_timeout() {
-    let (tx, mut rx) = bmrng::channel_with_timeout::<i32, i32>(1, Duration::from_millis(100));
+    let (tx, mut rx) = bmrng::channel_with_timeout::<Req>(1, Duration::from_millis(100));
     pause();
     tokio::spawn(async move {
-        let (_input, responder) = rx.recv().await.expect("Unexpected err");
+        let Payload { request: _, responder } = rx.recv().await.expect("Unexpected err");
         assert!(!responder.is_closed());
         advance(Duration::from_millis(200)).await;
         sleep(Duration::from_micros(1)).await;
@@ -192,17 +198,17 @@ async fn bounded_timeout() {
         panic!("Should have timed out");
     });
     assert!(!tx.is_closed());
-    let response = tx.send_receive(8).await;
-    assert_eq!(response, Err(RequestError::<i32>::RecvTimeoutError));
+    let response = tx.send_receive(Req(8)).await;
+    assert_eq!(response, Err(RequestError::<Req>::RecvTimeoutError));
 }
 
 #[tokio::test]
 async fn unbounded_timeout() {
     let (tx, mut rx) =
-        bmrng::unbounded::channel_with_timeout::<i32, i32>(Duration::from_millis(100));
+        bmrng::unbounded::channel_with_timeout::<Req>(Duration::from_millis(100));
     pause();
     tokio::spawn(async move {
-        let (_input, responder) = rx.recv().await.expect("Unexpected err");
+        let UnboundedPayload { request: _, responder } = rx.recv().await.expect("Unexpected err");
         assert!(!responder.is_closed());
         advance(Duration::from_millis(200)).await;
         sleep(Duration::from_micros(1)).await;
@@ -210,80 +216,80 @@ async fn unbounded_timeout() {
         panic!("Should have timed out");
     });
     assert!(!tx.is_closed());
-    let response = tx.send_receive(8).await;
-    assert_eq!(response, Err(RequestError::<i32>::RecvTimeoutError));
+    let response = tx.send_receive(Req(8)).await;
+    assert_eq!(response, Err(RequestError::<Req>::RecvTimeoutError));
 }
 
 #[tokio::test]
 async fn bounded_stream() {
-    let (tx, rx) = bmrng::channel::<i32, i32>(1);
+    let (tx, rx) = bmrng::channel::<Req>(1);
     tokio::spawn(async move {
         let mut stream = rx.into_stream();
-        while let Some((input, responder)) = stream.next().await {
+        while let Some(Payload { request, responder }) = stream.next().await {
             assert_eq!(responder.is_closed(), false);
-            let res = responder.respond(input * input);
+            let res = responder.respond(request.0 + 4);
             assert!(res.is_ok());
         }
     });
     assert!(!tx.is_closed());
-    assert_eq!(tx.send_receive(8).await, Ok(64));
+    assert_eq!(tx.send_receive(Req(8)).await, Ok(12));
     assert!(!tx.is_closed());
-    assert_eq!(tx.send_receive(3).await, Ok(9));
+    assert_eq!(tx.send_receive(Req(3)).await, Ok(7));
     assert!(!tx.is_closed());
-    assert_eq!(tx.send_receive(1).await, Ok(1));
+    assert_eq!(tx.send_receive(Req(1)).await, Ok(5));
     assert!(!tx.is_closed());
 }
 
 #[tokio::test]
 async fn unbounded_stream() {
-    let (tx, rx) = bmrng::unbounded_channel::<i32, i32>();
+    let (tx, rx) = bmrng::unbounded_channel::<Req>();
     tokio::spawn(async move {
         let mut stream = rx.into_stream();
-        while let Some((input, responder)) = stream.next().await {
+        while let Some(UnboundedPayload { request, responder }) = stream.next().await {
             assert!(!responder.is_closed());
-            let res = responder.respond(input * input);
+            let res = responder.respond(request.0 + 4);
             assert!(res.is_ok());
         }
     });
     assert!(!tx.is_closed());
-    assert_eq!(tx.send_receive(8).await, Ok(64));
+    assert_eq!(tx.send_receive(Req(8)).await, Ok(12));
     assert!(!tx.is_closed());
-    assert_eq!(tx.send_receive(3).await, Ok(9));
+    assert_eq!(tx.send_receive(Req(3)).await, Ok(7));
     assert!(!tx.is_closed());
-    assert_eq!(tx.send_receive(1).await, Ok(1));
+    assert_eq!(tx.send_receive(Req(1)).await, Ok(5));
     assert!(!tx.is_closed());
 }
 
 #[tokio::test]
 async fn req_receiver_into_inner() {
-    let (tx, rx) = bmrng::channel::<i32, i32>(1);
+    let (tx, rx) = bmrng::channel::<Req>(1);
     let stream = RequestReceiverStream::new(rx);
     let mut rx = stream.into_inner();
     tokio::spawn(async move {
-        let (input, responder) = rx.recv().await.expect("Unexpected err");
+        let Payload { request, responder } = rx.recv().await.expect("Unexpected err");
         assert!(!responder.is_closed());
-        let res = responder.respond(input * input);
+        let res = responder.respond(request.0 * 4);
         assert!(res.is_ok());
     });
     assert!(!tx.is_closed());
-    let response = tx.send_receive(8).await;
+    let response = tx.send_receive(Req(8)).await;
     assert!(tx.is_closed());
-    assert_eq!(response, Ok(64));
+    assert_eq!(response, Ok(32));
 }
 
 #[tokio::test]
 async fn req_unbounded_receiver_into_inner() {
-    let (tx, rx) = bmrng::unbounded_channel::<i32, i32>();
+    let (tx, rx) = bmrng::unbounded_channel::<Req>();
     let stream = UnboundedRequestReceiverStream::new(rx);
     let mut rx = stream.into_inner();
     tokio::spawn(async move {
-        let (input, responder) = rx.recv().await.expect("Unexpected err");
+        let UnboundedPayload { request, responder } = rx.recv().await.expect("Unexpected err");
         assert!(!responder.is_closed());
-        let res = responder.respond(input * input);
+        let res = responder.respond(request.0 * 4);
         assert!(res.is_ok());
     });
     assert!(!tx.is_closed());
-    let response = tx.send_receive(8).await;
+    let response = tx.send_receive(Req(8)).await;
     assert!(tx.is_closed());
-    assert_eq!(response, Ok(64));
+    assert_eq!(response, Ok(32));
 }


### PR DESCRIPTION
Note: This may be a sufficiently breaking change that it may be better to create another branch of this library and maintain it independently myself, rather than merging the changes into the current state of the library. The main purpose of this PR is discussion.
By using a `Request` trait with a type alias `Response` instead of two generic types, this library will be easier to use. In the future it could also be considered to allow transfering any type that implements `Request` in the channel by dynamic dispatching or something else. This would be more convenient when you need to pass values of multiple types, avoiding writing an enum and a lot of `match` boilerplate code.
Now I just finished the basic replacement and the current version does not compile through, with a kind of error that I can not understand and solve:
```
error[E0207]: the type parameter `R` is not constrained by the impl trait, self type, or predicates
   --> src\bounded.rs:127:6
    |
127 | impl<R: Request> ResponseReceiver<R::Response> {
    |      ^ unconstrained type parameter

error[E0207]: the type parameter `R` is not constrained by the impl trait, self type, or predicates
   --> src\bounded.rs:157:6
    |
157 | impl<R: Request> Responder<R::Response> {
    |      ^ unconstrained type parameter

error[E0207]: the type parameter `R` is not constrained by the impl trait, self type, or predicates
   --> src\unbounded.rs:109:6
    |
109 | impl<R: Request> UnboundedResponder<R::Response> {
    |      ^ unconstrained type parameter

For more information about this error, try `rustc --explain E0207`.
error: could not compile `bmrng` due to 3 previous errors
```
I found [a similar case on Stack Overflow](https://stackoverflow.com/questions/65129214/how-to-solve-this-unconstrained-type-parameter-error-in-rust), but it doesn't seem to help me understand how to solve the current error.